### PR TITLE
FR6989 added

### DIFF
--- a/CounterLib/CounterLib_t.h
+++ b/CounterLib/CounterLib_t.h
@@ -61,7 +61,7 @@ Modified by Frank Milburn, December 2015 to include the MSP430FR6989
     CL_TimerA0,    // FR5969 P1.2                 FR6989 P1.2*, P6.7*, P7.0* 
     CL_TimerA1,    // FR5969 P1.1*                FR6989 P1.1*, P4.4*, P5.2*
     CL_TimerB0     // FR5969 P2.0*                FR6989 P2.0, P3.3*, P5.7*
-    // Note: Pins with * are not easily accessible on LaucnhPads
+    // Note: Pins with * are not easily accessible on LaunchPads
   };
   
   // clk pin setup for each supported timer

--- a/CounterLib/CounterLib_t.h
+++ b/CounterLib/CounterLib_t.h
@@ -4,7 +4,8 @@ Created by Adrian Studer, August 2015.
 
 Distributed under MIT License, see license.txt for details.
 
-Modified by Frank Milburn, September 2015 to include the MSP430FR5969 LaunchPad and bug fixes
+Modified by Frank Milburn, September 2015 to include the MSP430FR5969 and bug fixes
+Modified by Frank Milburn, December 2015 to include the MSP430FR6989
 */
 
 #ifndef CounterLib_T_h
@@ -52,14 +53,15 @@ Modified by Frank Milburn, September 2015 to include the MSP430FR5969 LaunchPad 
   #define CL_TA2CLK_PIN_SETUP  { P2DIR &= ~BIT2; P2SEL |= BIT2; }
   #define CL_TB0CLK_PIN_SETUP  { P7DIR &= ~BIT7; P7SEL |= BIT7; }
 
-// definition of timers and their pins for MSP430FR5969
-#elif defined(__MSP430FR5969__)
+// definition of timers and their pins for MSP430FR5969 and MSP430FR6989
+#elif defined(__MSP430FR5969__) || defined(__MSP430FR6989__)
 
   enum CL_TIMER_t
   {
-    CL_TimerA0,    // FR5969 P1.2
-    CL_TimerA1,    // FR5969 P1.1 (note: pin not easily accessible on LP)
-    CL_TimerB0     // FR5969 P2.0 (note: pin not easily accessible on LP)
+    CL_TimerA0,    // FR5969 P1.2                 FR6989 P1.2*, P6.7*, P7.0* 
+    CL_TimerA1,    // FR5969 P1.1*                FR6989 P1.1*, P4.4*, P5.2*
+    CL_TimerB0     // FR5969 P2.0*                FR6989 P2.0, P3.3*, P5.7*
+    // Note: Pins with * are not easily accessible on LaucnhPads
   };
   
   // clk pin setup for each supported timer

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CounterLib-Energia
 A library for Energia that counts signal pulses received from an external source, like for example a clock.
 
-This library currently supports MSP430G2553, G2231, G2452, F5529 and FR5969.
+This library currently supports the MSP430G2553, G2231, G2452, F5529, FR5969, and FR6989.
 
 CounterLib leverages timer peripherals and uses I/O as external clock input for a 16 bit counter. 
 Using a Timer instead of interrupts allows to count very fast pulses.
@@ -36,14 +36,18 @@ parameter when declaring the counter. For example:
 	
 Below a list of supported timers and their pins. Note that not all MCUs support all timers.
 
-| Timer       | G2553,G2452,G2231 | F5529 | FR5969 |
-|------------ | -------	|------- |-------- |
-| CL_TimerA0  |  P1.0 	|  P1.0  |  P1.2  |
-| CL_TimerA1  |  n/a  	|  P1.6  |  P1.1* |
-| CL_TimerA2  |  n/a  	|  P2.2  |  n/a   |
-| CL_TimerB0  |  n/a  	|  P7.7* |  P2.0* |
+| Timer       | G2553,G2452,G2231 | F5529 | FR5969 | FR6989 |
+|------------ | -------	|------- |-------- |-------| 
+| CL_TimerA0  |  P1.0 	|  P1.0  |  P1.2  | P1.2^, P6.7#, P7.0# |
+| CL_TimerA1  |  n/a  	|  P1.6  |  P1.1* | P1.1^, P4.4#, P5.2# |
+| CL_TimerA2  |  n/a  	|  P2.2  |  n/a   | n/a |
+| CL_TimerB0  |  n/a  	|  P7.7* |  P2.0* | P2.0, P3.3#, P5.7#|
 
 Pins marked with * are not broken out on the LaunchPad.
+
+Pins marked with ^ are connected to a switch (user button) on the LaunchPad.
+
+Pins marked with # are connected to the LCD on the LaunchPad
 
 ### Dividers
 
@@ -51,7 +55,7 @@ For accurate counting you want a long measurement period, for example 100ms. But
 16 bit counter. For example a 1 MHz signal will count to 65535 (the maximum for 16 bit) in just 65 ms. This is when
 clock dividers come in handy.
 
-Depending on the MCU, the timers have one (G2553, G2452, G2231) or two (F5529, FR5969) dividers. The dividers
+Depending on the MCU, the timers have one (G2553, G2452, G2231) or two (F5529, FR5969, FR6989) dividers. The dividers
 can be set as optional parameter of the start() function.
 
 	MyCounter.start(divider1, divider2);

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ parameter when declaring the counter. For example:
 
 	Counter<CL_TimerA1> MyCounter; // use timer A1, which uses pin P1.6 as input
 	
-Below a list of supported timers and their pins. Note that not all MCUs support all timers.
+Below a list of supported timers and their pins. Note that not all MCUs support all timers and that some timers may be on multiple pins.
 
 | Timer       | G2553,G2452,G2231 | F5529 | FR5969 | FR6989 |
 |------------ | -------	|------- |-------- |-------| 

--- a/README.md
+++ b/README.md
@@ -38,16 +38,12 @@ Below a list of supported timers and their pins. Note that not all MCUs support 
 
 | Timer       | G2553,G2452,G2231 | F5529 | FR5969 | FR6989 |
 |------------ | -------	|------- |-------- |-------| 
-| CL_TimerA0  |  P1.0 	|  P1.0  |  P1.2  | P1.2^, P6.7#, P7.0# |
-| CL_TimerA1  |  n/a  	|  P1.6  |  P1.1* | P1.1^, P4.4#, P5.2# |
+| CL_TimerA0  |  P1.0 	|  P1.0  |  P1.2  | P1.2*, P6.7*, P7.0* |
+| CL_TimerA1  |  n/a  	|  P1.6  |  P1.1* | P1.1*, P4.4*, P5.2* |
 | CL_TimerA2  |  n/a  	|  P2.2  |  n/a   | n/a |
-| CL_TimerB0  |  n/a  	|  P7.7* |  P2.0* | P2.0, P3.3#, P5.7#|
+| CL_TimerB0  |  n/a  	|  P7.7* |  P2.0* | P2.0, P3.3*, P5.7*|
 
-Pins marked with * are not broken out on the LaunchPad.
-
-Pins marked with ^ are connected to a switch (user button) on the LaunchPad.
-
-Pins marked with # are connected to the LCD on the LaunchPad
+Pins marked with * are not broken out on the LaunchPad or are difficult to access.
 
 ### Dividers
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Below a list of supported timers and their pins. Note that not all MCUs support 
 
 | Timer       | G2553,G2452,G2231 | F5529 | FR5969 | FR6989 |
 |------------ | -------	|------- |-------- |-------| 
-| CL_TimerA0  |  P1.0 	|  P1.0  |  P1.2  | P1.2*, P6.7*, P7.0* |
-| CL_TimerA1  |  n/a  	|  P1.6  |  P1.1* | P1.1*, P4.4*, P5.2* |
+| CL_TimerA0  |  P1.0 	|  P1.0  |  P1.2  | P1.2* P6.7* P7.0* |
+| CL_TimerA1  |  n/a  	|  P1.6  |  P1.1* | P1.1* P4.4* P5.2* |
 | CL_TimerA2  |  n/a  	|  P2.2  |  n/a   | n/a |
-| CL_TimerB0  |  n/a  	|  P7.7* |  P2.0* | P2.0, P3.3*, P5.7*|
+| CL_TimerB0  |  n/a  	|  P7.7* |  P2.0* | P2.0 P3.3* P5.7*|
 
 Pins marked with * are not broken out on the LaunchPad or are difficult to access.
 


### PR DESCRIPTION
Added the FR6989 and updated the documentation.  It is quite straight forward - uses the same clocks and definitions as the the FR5969.  So I just added a || to the FR5969 section and changed the documentation.  The only twist is that the clocks can accept input from more than one pin.

I tested TA0CLK on P2.0 which is one of the standard 40 pins on the FR5969 LaunchPad at 1kHz sourced from my oscilloscope.  Also tested TA1CLK which is attached to button S1 (P1.1) by tapping on it and letting it count that.  I then hooked it up to a F5529 and tested TB0CLK successfully.

The only thing is I seemed to have messed up the Energia file system on my computer and I had to create a new folder outside of "libraries" to test it.  I have not figured out how I did that yet.  The bottom line is that I haven't tested it by putting it in the "libraries" folder and then accessing it with #include <CounterLib_t.h>.  I have been accessing it with #include "CounterLib_t.h".  I don't think that makes a difference, just letting you know.
